### PR TITLE
refactor: stabilize node heartbeat control

### DIFF
--- a/internal/mq/topic.go
+++ b/internal/mq/topic.go
@@ -14,11 +14,12 @@ const (
 	NodePackages
 	KillNodeProcess
 	StartNodeSpeedtest
+	GoodbyeNetwork
 )
 
 func (t Topic) Sensitive() bool {
 	switch t {
-	case HelloNetwork, JoinNetwork, AuthenticateNetwork, NodeConnections, NodeProcesses, KillNodeProcess:
+	case HelloNetwork, JoinNetwork, AuthenticateNetwork, NodeConnections, NodeProcesses, KillNodeProcess, GoodbyeNetwork:
 		return true
 	default:
 		return false

--- a/internal/mq/topic_test.go
+++ b/internal/mq/topic_test.go
@@ -13,8 +13,8 @@ func TestTopicSensitive(t *testing.T) {
 		output bool
 	}{
 		{
-			desc:   "hello, join, authenticate network, node connections, node processes, kill node process are sensitive",
-			input:  []mq.Topic{mq.HelloNetwork, mq.JoinNetwork, mq.AuthenticateNetwork, mq.NodeConnections, mq.NodeProcesses, mq.KillNodeProcess},
+			desc:   "hello, goodbye, join, authenticate network, node connections, node processes, kill node process are sensitive",
+			input:  []mq.Topic{mq.HelloNetwork, mq.GoodbyeNetwork, mq.JoinNetwork, mq.AuthenticateNetwork, mq.NodeConnections, mq.NodeProcesses, mq.KillNodeProcess},
 			output: true,
 		},
 		{

--- a/internal/service/node-scheduler.go
+++ b/internal/service/node-scheduler.go
@@ -52,15 +52,15 @@ func NewNodeSchedulerService(
 	// schedule goroutine that checks for any networ node that have gone missing
 	go func() {
 		for {
-			t := time.Now()
+			t := time.Now().UTC()
 			n := network()
 			lastSeenTimeout := cfg().NodeLastSeenTimeout.Duration()
 			for _, n := range n {
-				if n.LastSeen.Sub(t).Abs() < lastSeenTimeout {
+				if !n.Online {
 					continue
 				}
 
-				if !n.Online {
+				if n.LastSeen.UTC().Sub(t).Abs() < lastSeenTimeout {
 					continue
 				}
 


### PR DESCRIPTION
improvements:
- nodes now try to publish one last message to master before closing/exiting, to notify them that these will become offline
- convert node last seen time to UTC in order to compare it with the current time (UTC) and see if it exceeds the maximum amount of time a node cannot be seen (`lastSeenTimeout`)